### PR TITLE
feat(next): add Umami analytics script

### DIFF
--- a/next/src/app/layout.tsx
+++ b/next/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import Script from "next/script";
 import { getStrapiGlobalData } from "../utils/fetchStrapiData";
 import NavBar from "../sections/NavBar";
 import Footer from "../sections/Footer";
@@ -29,6 +30,13 @@ export default async function RootLayout({
 	}
 	return (
 		<html lang="fr">
+			<head>
+				<Script
+					src="https://analytics.j42l.ch/script.js"
+					data-website-id="a83bec4c-2654-4cc6-a97b-266d5297cb16"
+					strategy="afterInteractive"
+				/>
+			</head>
 			<body>
 			{
 				global


### PR DESCRIPTION
## Objectif
Intégration du script de suivi analytique Umami sur le site.

## Résumé des changements
- Ajout du composant `Script` de Next.js dans `layout.tsx` avec le script Umami self-hosted sur `analytics.j42l.ch`

## Décisions techniques
Utilisation de `next/script` avec `strategy="afterInteractive"` plutôt qu'une balise `<script>` brute pour respecter le cycle de vie Next.js et éviter de bloquer le rendu.